### PR TITLE
 Make MultiTest example thread-safe by locking `push!(ts.results, t)`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
+  - 1.2
+  - 1.3
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,19 @@ julia:
   - 1.2
   - 1.3
   - nightly
+env:
+  - JULIA_NUM_THREADS=1
+  - JULIA_NUM_THREADS=2
+jobs:
+  exclude:
+  - julia: 1.2
+    env: JULIA_NUM_THREADS=2
+
 matrix:
   allow_failures:
     - julia: nightly
   fast_finish: true
+
 notifications:
   email: false
 after_success:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Nathan Daly"]
 version = "0.1.0"
 
 [compat]
-julia = "1"
+julia = ">=1.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/examples/MultiTest.jl
+++ b/examples/MultiTest.jl
@@ -1,84 +1,114 @@
 module MultiTest
 
-using TaskHeritableStorage
-
-const THS = TaskHeritableStorage
-
 # Override @testset to use task-heritable storage
 import Test
 
+@eval Test using TaskHeritableStorage
 @eval Test begin
     #-----------------------------------------------------------------------
     # Various helper methods for test sets
 
-#    function get_testset()
-#        testsets = get($THS.@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-#        return isempty(testsets) ? fallback_testset : testsets[end]
-#    end
-#
-#    function push_testset(ts::AbstractTestSet)
-#        testsets = get($THS.@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-#        push!(testsets, ts)
-#        setindex!($THS.@task_heritable_storage(), testsets, :__BASETESTNEXT__)
-#    end
-#
-#    function pop_testset()
-#        testsets = get($THS.@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-#        ret = isempty(testsets) ? fallback_testset : pop!(testsets)
-#        setindex!($THS.@task_heritable_storage(), testsets, :__BASETESTNEXT__)
-#        return ret
-#    end
-#
-#    function get_testset_depth()
-#        testsets = get($THS.@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-#        return length(testsets)
-#    end
+    # Update Test helper methods to store the stack of active testsets in Task Heritable
+    # Storage instead of in task_local_storage, which makes Test support concurrent testsets.
 
-function get_testset()
-    # Get the currently executing testset, falling back to those inherited from parent tasks
-    testsets = get(task_local_storage(), :__BASETESTNEXT__,
-                    # If not present in task_local_storage, read it from (potential) parent
-                    get($THS.@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[]))
-    return isempty(testsets) ? fallback_testset : testsets[end]
-end
+    # This is not enough to make them *thread-safe*, since the `results` array in
+    # DefaultTestSet is written to in parallel. The next block of code, below, addresses
+    # that by adding a lock around setters. A nicer fix would be to use a lock-free accumulator.
 
-function push_testset(ts::AbstractTestSet)
-    @info "push_testset(" ts ")"
-    testsets = get(task_local_storage(), :__BASETESTNEXT__,
-                    # If not present in task_local_storage, copy it from (potential) parent
-                    get($THS.@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[]))
-    # copy the array so we aren't modifying the parent Task's testsets
-    testsets = copy(testsets)
-    push!(testsets, ts)
-    # Overwrite the binding so our child-tasks share this array.
-    setindex!($THS.@task_heritable_storage(), testsets, :__BASETESTNEXT__)
-    # Set the binding in task_local_storage as well, and use that from now on.
-    setindex!(task_local_storage(), testsets, :__BASETESTNEXT__)
-end
+    function get_current_testsets()
+        # Get the currently executing testset, falling back to those inherited from parent tasks
+        get!(task_local_storage(), :__BASETESTNEXT__) do
+            # If not present in task_local_storage, copy only the parent from parent's array
+            parent_testsets = get(@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[])
+            testsets = length(parent_testsets) >= 1 ? AbstractTestSet[parent_testsets[end]] : AbstractTestSet[]
 
-function pop_testset()
-    @info "pop_testset()"
-    @assert haskey(task_local_storage(), :__BASETESTNEXT__) """
-        Programming Error: I misunderstand something; this should never happen.
-        Trying to pop_testset() with nothing in task_local_storage()
-        """
-    testsets = get(task_local_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-    ret = isempty(testsets) ? fallback_testset : pop!(testsets)
-    # Overwrite the binding so our child-tasks see the updated testsets
-    setindex!($THS.@task_heritable_storage(), testsets, :__BASETESTNEXT__)
-    # This line is copied from the old thing, but should be redundant
-    setindex!(task_local_storage(), testsets, :__BASETESTNEXT__)
-    return ret
-end
+            # Write over the testsets array in THS with our copy, so we can't update parent
+            @task_heritable_storage()[:__BASETESTNEXT__] = testsets
+            testsets
+        end
+    end
 
-function get_testset_depth()
-    # Read from the inherited set of TestSets
-    testsets = get(task_local_storage(), :__BASETESTNEXT__,
-                    # If not present in task_local_storage, read it from (potential) parent
-                    get($THS.@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[]))
-    return length(testsets)
-end
+    function get_testset()
+        testsets = get_current_testsets()
+        return isempty(testsets) ? fallback_testset : testsets[end]
+    end
 
+    function push_testset(ts::AbstractTestSet)
+        testsets = get_current_testsets()
+        push!(testsets, ts)
+    end
+
+    function pop_testset()
+        testsets = get_current_testsets()
+        ret = isempty(testsets) ? fallback_testset : pop!(testsets)
+        return ret
+    end
+
+    function get_testset_depth()
+        testsets = get_current_testsets()
+        return length(testsets)
+    end
+
+    # ------------------------------------------
+    # Make Test _thread-safe_ by locking when writing to the results of a parent testset:
+
+    if VERSION >= v"1.3-"
+
+        test_lock_ = ReentrantLock()
+
+        record(ts::DefaultTestSet, t::Broken) = begin
+            lock(test_lock_); push!(ts.results, t); unlock(test_lock_);
+            t
+        end
+        # For a passed result, do not store the result since it uses a lot of memory
+        record(ts::DefaultTestSet, t::Pass) = begin
+            lock(test_lock_); ts.n_passed += 1; unlock(test_lock_);
+            t
+        end
+
+        # For the other result types, immediately print the error message
+        # but do not terminate. Print a backtrace.
+        function record(ts::DefaultTestSet, t::Union{Fail, Error})
+            if myid() == 1
+                printstyled(ts.description, ": ", color=:white)
+                # don't print for interrupted tests
+                if !(t isa Error) || t.test_type != :test_interrupted
+                    print(t)
+                    # don't print the backtrace for Errors because it gets printed in the show
+                    # method
+                    if !isa(t, Error)
+                        Base.show_backtrace(stdout, scrub_backtrace(backtrace()))
+                    end
+                    println()
+                end
+            end
+            lock(test_lock_); push!(ts.results, t); unlock(test_lock_);
+            t, isa(t, Error) || backtrace()
+        end
+
+        # When a DefaultTestSet finishes, it records itself to its parent
+        # testset, if there is one. This allows for recursive printing of
+        # the results at the end of the tests
+        record(ts::DefaultTestSet, t::AbstractTestSet) = begin
+            lock(test_lock_); push!(ts.results, t); unlock(test_lock_);
+        end
+
+
+        function record(ts::DefaultTestSet, t::LogTestFailure)
+            if myid() == 1
+                printstyled(ts.description, ": ", color=:white)
+                print(t)
+                Base.show_backtrace(stdout, scrub_backtrace(backtrace()))
+                println()
+            end
+            # Hack: convert to `Fail` so that test summarization works correctly
+            lock(test_lock_);
+            push!(ts.results, Fail(:test, t.orig_expr, t.logs, nothing, t.source))
+            unlock(test_lock_);
+            t
+        end
+
+    end  # VERSION >= v1.3
 end
 
 end

--- a/examples/MultiTest.jl
+++ b/examples/MultiTest.jl
@@ -17,11 +17,13 @@ import Test
 
     function get_current_testsets()
         # Get the stack of currently executing testsets, inherited from parent tasks
-        get(task_local_storage(), :__BASETESTNEXT__) do
+        # NOTE: Use a new key, in case anything was set with the old key before evaling this
+        get!(task_local_storage(), :__NHD_BASETESTNEXT__) do
             # _Copy_ the array from parent Tasks, to _fork_ the array in child tasks.
-            testsets = copy(get(@task_heritable_storage(), :__BASETESTNEXT__, AbstractTestSet[]))
+            testsets = copy(get(@task_heritable_storage(), :__NHD_BASETESTNEXT__, AbstractTestSet[]))
             # Write over the testsets array in THS with our copy, so child tasks will inherit our fork.
-            @task_heritable_storage()[:__BASETESTNEXT__] = testsets
+            @task_heritable_storage()[:__NHD_BASETESTNEXT__] = testsets
+            @show testsets
             testsets
         end
     end

--- a/test/MultiTest.jl
+++ b/test/MultiTest.jl
@@ -18,7 +18,7 @@ begin
     t = @testset "outer" begin
         @sync begin
             @async begin
-                @testset "inner" begin
+                @testset "inner1" begin
                     @test true
                 end
             end
@@ -39,7 +39,7 @@ if VERSION >= v"1.3-"
 
     # Test that Testsets now work correctly across multiple threads
     @testset "outerest" begin
-      @testset "outerer" for _ in 1:100
+      @testset "outerer$i" for i in 1:3
         t = @testset "outer" begin
             @sync begin
                 Threads.@spawn begin

--- a/test/MultiTest.jl
+++ b/test/MultiTest.jl
@@ -6,8 +6,8 @@ using TaskHeritableStorage
 # NOTE: This overrides the behavior of Test functions
 include("../examples/MultiTest.jl")
 
-#using Test
-using Testy.JuliaTestModified
+using Test
+#using Testy.JuliaTestModified
 
 @testset "" begin
     @test true
@@ -35,9 +35,11 @@ begin
 end
 
 if VERSION >= v"1.3-"
+    @show Threads.nthreads()
 
+    # Test that Testsets now work correctly across multiple threads
     @testset "outerest" begin
-      @testset "outerer" for _ in 1:10
+      @testset "outerer" for _ in 1:100
         t = @testset "outer" begin
             @sync begin
                 Threads.@spawn begin

--- a/test/MultiTest.jl
+++ b/test/MultiTest.jl
@@ -34,7 +34,7 @@ begin
     @test length(t.results) == 2
 end
 
-if VERSION >= v"1.3-"
+@static if VERSION >= v"1.3-"
     @show Threads.nthreads()
 
     # Test that Testsets now work correctly across multiple threads

--- a/test/TaskHeritableStorage.jl
+++ b/test/TaskHeritableStorage.jl
@@ -20,16 +20,20 @@ fetch(@async begin
 end)
 
 @testset "assigning doesn't affect parent tasks" begin
-    @task_heritable_storage()[:a] = 1
     @sync @async begin
-        @test @task_heritable_storage()[:a] == 1
+        @task_heritable_storage()[:a] = 1
+        @sync @async begin
+            @test @task_heritable_storage()[:a] == 1
 
-        # Update it to 2 within this Task
-        @task_heritable_storage()[:a] = 2
-        @test @task_heritable_storage()[:a] == 2
+            # Update it to 2 within this Task
+            @task_heritable_storage()[:a] = 2
+            @test @task_heritable_storage()[:a] == 2
+        end
+        # In the parent task, the value is still 1
+        @test @task_heritable_storage()[:a] == 1
     end
-    # In the parent task, the value is still 1
-    @test @task_heritable_storage()[:a] == 1
+    # In the outermost task, the value was never set
+    @test !haskey(@task_heritable_storage(), :a)
 end
 
 @testset "callbacks" begin

--- a/test/TaskHeritableStorage.jl
+++ b/test/TaskHeritableStorage.jl
@@ -51,10 +51,14 @@ end
         @test sort(1:10, lt=less_than) == 1:10
 
         # SURPRISE: the author of sort decides to parallelize it (represented via `psort`)!
-        @test_throws TaskFailedException psort(1:10, lt=less_than) == 1:10
+        @test_throws Exception psort(1:10, lt=less_than) == 1:10
         # The error is a KeyError, because :reverse is no longer in the task_local_storage:
         e = try                          psort(1:10, lt=less_than) == 1:10; catch e; e end
-        @test e.task.exception == KeyError(:reverse)
+        @static if VERSION >= v"1.3-"
+            @test e.task.exception == KeyError(:reverse)
+        else
+            @test e == KeyError(:reverse)
+        end  # VERSION
     end
 
     @testset "SOLUTION: task_heritable_storage is composable" begin


### PR DESCRIPTION
Changing Test to use `task_heritable_storage` is enough to make it Concurrent. To make it thread-safe, we need to also make the writes to record finished TestSets in their parent TestSets thread-safe.

This can be done either with locks (as I've done here, for simplicity), or by changing the TestSet structure to use lock-free accumulators (as we're doing in Testy.jl). 


Here, in e3d0b5889cb09, we use `task_local_storage()` as a cache to implement forking the parent Task's array when creating new Child Tasks.  This avoids having to copy the array on every access in order to ensure it's forked.
This is because for some situations (such as this one), we don't just want to copy a Tasks _bindings_ to its children, we actually want to copy its _values_. Since THS currently doesn't have any way to configure this, we achieve it by checking `task_local_storage()` to see whether we have forked the array before.