### PR TITLE
Add simple Tracing example.

### DIFF
--- a/examples/ThreadSafeAccumulators.jl
+++ b/examples/ThreadSafeAccumulators.jl
@@ -1,0 +1,48 @@
+module ThreadSafeAccumulators #end
+
+export Accumulator
+
+"""
+    Accumulator{T}
+A thread-safe, push-only vector abstraction.
+Collecting the results should only be done with all threads have finished pushing.
+
+# Examples:
+```julia
+julia> a = Accumulator();
+
+julia> for i in 1:5
+           Threads.@spawn push!(a, i)
+       end
+
+julia> collect(a)
+5-element Array{Any,1}:
+ 4
+ 5
+ 2
+ 1
+ 3
+```
+"""
+struct Accumulator{T}
+    nvectors::NTuple{Threads.nthreads(), Vector{T}}
+    Accumulator{T}() where T = new{T}(Tuple(T[] for _ in 1:Threads.nthreads()))
+end
+Accumulator() = Accumulator{Any}()
+
+Base.collect(a::Accumulator) = vcat(a.nvectors...)
+Base.push!(a::Accumulator, v...) = (push!(a.nvectors[Threads.threadid()], v...); a)
+
+
+# Construct from existing collections
+Base.convert(t::Type{Accumulator}, collection) = t(collection)
+Accumulator(collection) = Accumulator{eltype(collection)}(collection)
+function Accumulator{T}(collection) where T
+    a = Accumulator{T}()
+    push!(a, collection...)
+end
+
+# Helpers
+Base.eltype(::Type{Accumulator{T}}) where T = T
+
+end

--- a/examples/Tracing.jl
+++ b/examples/Tracing.jl
@@ -1,0 +1,33 @@
+module Tracing #end
+
+export clear_traces, trace, get_traces
+
+using TaskHeritableStorage
+
+include("ThreadSafeAccumulators.jl")
+using .ThreadSafeAccumulators
+
+function clear_traces()
+    global task_traces = Accumulator()
+    global func_traces = Accumulator()
+end
+clear_traces()
+
+function trace()
+    ths = @task_heritable_storage()
+    # If this is the first time tracing this Task, update the current task
+    get!(task_local_storage(), (@__MODULE__, :task_is_traced)) do
+        parent = get!(ths, :current_task, nothing)
+        current = ths[:current_task] = current_task()
+        push!(task_traces, (parent, current))
+        true
+    end
+
+    push!(func_traces, (ths[:current_task], Base.stacktrace()))
+end
+
+function get_traces()
+    collect(task_traces), collect(func_traces)
+end
+
+end

--- a/test/ThreadSafeAccumulators.jl
+++ b/test/ThreadSafeAccumulators.jl
@@ -1,0 +1,19 @@
+module ThreadSafeAccumulatorsRuntests
+
+using Test
+include("../examples/ThreadSafeAccumulators.jl")
+using .ThreadSafeAccumulators
+
+@test collect(Accumulator()) == Any[]
+@test collect(Accumulator{Int}()) == Int[]
+@test collect(push!(Accumulator{Int}(), 2)) == [2]
+@test collect(push!(push!(Accumulator{Int}(), 1,2),3,4)) == 1:4
+# constructors / convert
+@test collect(Accumulator([])) == collect(Accumulator())
+@test collect(Accumulator([1,2,3])) == 1:3
+@test collect(Accumulator{Float64}([1])) == Float64[1]
+
+@test eltype(Accumulator{Int}()) == Int
+@test eltype(Accumulator([1,2,3])) == Int
+
+end

--- a/test/Tracing.jl
+++ b/test/Tracing.jl
@@ -3,6 +3,12 @@ module TracingTests #end
 include("../examples/Tracing.jl")
 using .Tracing
 
+@static if VERSION >= v"1.3-"
+    import Base.Threads: @spawn
+else
+    macro spawn(e) esc(:(@async(e))) end
+end
+
 begin
     trace()
     tasks, funcs = get_traces()
@@ -13,12 +19,12 @@ end
 begin
     clear_traces()
     trace()
-    Threads.@spawn begin
+    @spawn begin
         trace()
-        Threads.@spawn begin
+        @spawn begin
             trace()
         end
-        Threads.@spawn begin
+        @spawn begin
             trace()
         end
     end

--- a/test/Tracing.jl
+++ b/test/Tracing.jl
@@ -1,0 +1,31 @@
+module TracingTests #end
+
+include("../examples/Tracing.jl")
+using .Tracing
+
+begin
+    trace()
+    tasks, funcs = get_traces()
+    @info tasks
+    @info funcs
+end
+
+begin
+    clear_traces()
+    trace()
+    Threads.@spawn begin
+        trace()
+        Threads.@spawn begin
+            trace()
+        end
+        Threads.@spawn begin
+            trace()
+        end
+    end
+
+    tasks, funcs = get_traces()
+    @info tasks
+    @info funcs
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,7 @@ using TaskHeritableStorage  # Load the module (overrides Task() constructor)
 include("TaskHeritableStorage.jl")
 
 # Examples
-include("MultiTest.jl")  # Note that this currently modifies Test.@testset behavior
+include("ThreadSafeAccumulators.jl")
+include("Tracing.jl")
+# NOTE: MultiTest.jl currently modifies Test.@testset behavior, so keep it last:
+include("MultiTest.jl")


### PR DESCRIPTION
- A `trace()` function (that must be added to code by the user) that
creates a tree of Tasks from which `trace()` is called.

Note that this _doesn't_ create a tree of _all_ tasks, which currently
isn't possible, since there's no way to add code to be triggered on
every new Task creation (like a callback).