### PR TITLE
Switch to "Proposal 2": Have users override a `fork` function for their (k,v) pair types

### DIFF
--- a/examples/MultiTest.jl
+++ b/examples/MultiTest.jl
@@ -15,16 +15,16 @@ import Test
     # DefaultTestSet is written to in parallel. The next block of code, below, addresses
     # that by adding a lock around setters. A nicer fix would be to use a lock-free accumulator.
 
+    # Key for Task Local Storage
+    struct TestSetStackKey end
+
+    # Fork the stack of testsets when new tasks are spawned, so that child tasks don't
+    # clobber eachother's stacks.
+    TaskHeritableStorage.fork_task_local_storage(k::TestSetStackKey, v) = (k, copy(v))
+
+    # Get the stack of currently executing testsets, inherited from parent tasks
     function get_current_testsets()
-        # Get the stack of currently executing testsets, inherited from parent tasks
-        # NOTE: Use a new key, in case anything was set with the old key before evaling this
-        get!(task_local_storage(), :__NHD_BASETESTNEXT__) do
-            # _Copy_ the array from parent Tasks, to _fork_ the array in child tasks.
-            testsets = copy(get(@task_heritable_storage(), :__NHD_BASETESTNEXT__, AbstractTestSet[]))
-            # Write over the testsets array in THS with our copy, so child tasks will inherit our fork.
-            @task_heritable_storage()[:__NHD_BASETESTNEXT__] = testsets
-            testsets
-        end
+        get!(task_local_storage(), TestSetStackKey(), AbstractTestSet[])
     end
 
     function get_testset()

--- a/examples/ThreadSafeAccumulators.jl
+++ b/examples/ThreadSafeAccumulators.jl
@@ -36,6 +36,7 @@ Base.push!(a::Accumulator, v...) = (push!(a.nvectors[Threads.threadid()], v...);
 
 # Construct from existing collections
 Base.convert(t::Type{Accumulator}, collection) = t(collection)
+Base.convert(t::Type{<:Accumulator}, x::Accumulator{S}) where {S} = t(collect(x))
 Accumulator(collection) = Accumulator{eltype(collection)}(collection)
 function Accumulator{T}(collection) where T
     a = Accumulator{T}()

--- a/examples/Tracing.jl
+++ b/examples/Tracing.jl
@@ -1,33 +1,58 @@
 module Tracing #end
 
-export clear_traces, trace, get_traces
+export tracetasks, @tracetasks
 
 using TaskHeritableStorage
 
 include("ThreadSafeAccumulators.jl")
 using .ThreadSafeAccumulators
 
-function clear_traces()
-    global task_traces = Accumulator()
-    global func_traces = Accumulator()
+# Key for Task Local Storage
+struct TraceTLSKey
+    id::Int  # Use a unique TLS key for each trace to allow composable tracing
+    TraceTLSKey() = new(traceid[] += 1)
 end
-clear_traces()
+traceid = Threads.Atomic{Int}(0)
+struct TraceTLSValue
+    task_edges::Accumulator{Pair{Task,Task}}
+    parent_task::Task  # Set to current_task()
+    TraceTLSValue() = new(Accumulator([(current_task() => current_task())]), current_task())
+    TraceTLSValue(edges, task) = new(edges, task)
+end
 
-function trace()
-    ths = @task_heritable_storage()
-    # If this is the first time tracing this Task, update the current task
-    get!(task_local_storage(), (@__MODULE__, :task_is_traced)) do
-        parent = get!(ths, :current_task, nothing)
-        current = ths[:current_task] = current_task()
-        push!(task_traces, (parent, current))
-        true
+function TaskHeritableStorage.fork_task_local_storage(k, v::TraceTLSValue)
+    # It is thread-safe to push! to an Accumulator
+    push!(v.task_edges, v.parent_task => current_task())
+    # Fork a new "current task", but share the same edges accumulator:
+    (k, TraceTLSValue(v.task_edges, current_task()))
+end
+
+
+"""
+    @tracetasks expr
+
+Equivalent to tracetasks() do ; expr; end
+"""
+macro tracetasks(e)
+    :(tracetasks(()->$(esc(e))))
+end
+
+"""
+    @tracetasks expr
+    tracetasks() do ; end
+    tracetasks(f::Function)
+
+Run a function and trace all tasks that are spawned during its execution.
+Returns an Array of pairs from `parent_task => child_task`. The root task is represented
+with a special self-edge `t => t`.
+"""
+function tracetasks(f::Function)
+    tls = task_local_storage()
+    key = TraceTLSKey()
+    task_local_storage(key, TraceTLSValue()) do
+        f()
+        return collect(task_local_storage()[key].task_edges)
     end
-
-    push!(func_traces, (ths[:current_task], Base.stacktrace()))
 end
 
-function get_traces()
-    collect(task_traces), collect(func_traces)
-end
-
-end
+end  # module

--- a/src/TaskHeritableStorage.jl
+++ b/src/TaskHeritableStorage.jl
@@ -1,49 +1,37 @@
 module TaskHeritableStorage # end
 
-export task_heritable_storage, @task_heritable_storage
-
-const _heritable_storage_name = Symbol("##__nhdaly-task_heritable_storage__##")
-
 """
-    task_heritable_storage(m::Module) :: IdDict
-    @task_heritable_storage() :: IdDict
+    fork_task_local_storage(key, value) -> (key,value) or nothing
 
-Return the current task's task-heritable storage dictionary. Note that storage in this
-dictionary is copied to all tasks spawned from this task, so it is safe to rely on this
-storage being available from any subsequent accesses within this Task or nestsed Tasks.
+Whenever a new `Task` is created, all `(key,value)` pairs in the parent Task's
+`task_local_storage` are passed to this function, which gives a chance to _fork_ those pairs
+into the new child `Task`'s task local storage.
 
-NOTE: Since this storage could be accessed from nested Tasks, accessing or modifying mutable
-_values_ is not thread-safe, and must be treated like any global mutable state (e.g. locked
-via a mutex).
+Whatever new `(key, value)` pair is returned will be inserted into the new Task's
+`task_local_storage`. If `nothing` is returned, the child Task's storage will not be
+modified. This is the default behavior.
 
-Storage is namespaced per-module, so you do not need to worry about your variable names
-colliding with other modules.
+This function is called from inside the newly created `Task` before anything else happens,
+so within this function `current_task()` will return the new Task.
 """
-function task_heritable_storage(m::Module)
-    get!(_task_heritable_storage_all_modules(), m, IdDict{Any,Any}())
+function fork_task_local_storage(key, value)
+    nothing
 end
-_task_heritable_storage_all_modules() = get!(task_local_storage(), _heritable_storage_name, IdDict{Module,Any}())
 
-# Note that overloaded macros can only be documented once, the documentation is provided at
-# the bottom of this file.
-macro task_heritable_storage()
-    :(task_heritable_storage($__module__))  # No esc needed, since no user inputs
-end
 
 # ----------------------
 # Replace the definition of Core._Task() to clone task_heritable_storage on construction.
 
-function _has_task_heritable_storage(m::Module)
-    haskey(task_local_storage(), _heritable_storage_name) &&
-        haskey(_task_heritable_storage_all_modules(), m)
-end
-
-function _clone_task_heritable_storage(dict)
-    # Copy each module's IdDict, to provide the shallow-copy guaranteed by the spec.
-    task_local_storage()[_heritable_storage_name] = IdDict(
-        m => copy(d)
-        for (m, d) in dict
-    )
+function _fork_task_local_storage_from_parent(parent_tls)
+    tls = task_local_storage()
+    # Fork all (k,v) pairs from the parent's TLS into this task's TLS
+    for (k, v) in parent_tls
+        out = fork_task_local_storage(k,v)
+        if out !== nothing
+            (newkey, newval) = out
+            tls[newkey] = newval
+        end
+    end
 end
 
 # DANGEROUS: Override the Core Task() constructor to copy the task heritable storage
@@ -53,10 +41,10 @@ function __Task(@nospecialize(f), reserved_stack::Int, completion_future)
     return ccall(:jl_new_task, Ref{Task}, (Any, Any, Int), f, completion_future, reserved_stack)
 end
 function Core._Task(@nospecialize(f), reserved_stack::Int, completion_future)
-    if haskey(task_local_storage(), _heritable_storage_name)
-        let all_storage = _task_heritable_storage_all_modules()
+    if current_task().storage !== nothing
+        let parent_tls = task_local_storage()
             wrapped = () -> begin
-                _clone_task_heritable_storage(all_storage);
+                _fork_task_local_storage_from_parent(parent_tls);
                 f();
             end
             return __Task(wrapped, reserved_stack, completion_future)
@@ -64,44 +52,6 @@ function Core._Task(@nospecialize(f), reserved_stack::Int, completion_future)
     else
         return __Task(f, reserved_stack, completion_future)
     end
-end
-
-
-# -------- Convenience APIs ----------------
-"""
-    task_heritable_storage(m::Module, key, value) do ... end
-    @task_heritable_storage(key, value) do ... end
-
-Call the function `body` with a modified task-heritable storage, in which `value` is assigned to
-`key`; the previous value of `key`, or lack thereof, is restored afterwards.
-"""
-function task_heritable_storage(body::Function, m::Module, key, val)
-    tls = task_heritable_storage(m)
-    hadkey = haskey(tls, key)
-    old = get(tls, key, nothing)
-    tls[key] = val
-    try
-        return body()
-    finally
-        hadkey ? (tls[key] = old) : delete!(tls, key)
-    end
-end
-
-# Note that overloaded macros can only be documented once, so this documents both macros
-"""
-    @task_heritable_storage()  :: IdDict
-
-This is simply a synonym for [`task_heritable_storage(@__MODULE__)`](@ref).
-
-───────────────────────────────────────────────────────────────────────────
-
-    @task_heritable_storage(key, value) do ... end
-
-This is simply a synonym for `task_heritable_storage(@__MODULE__, key, value) do ... end`
-"""
-macro task_heritable_storage(body, key, value)
-    # @task_heritable_storage(key, value) do ... end
-    esc(:($task_heritable_storage($body, $__module__, $key, $value)))
 end
 
 

--- a/test/TaskHeritableStorage.jl
+++ b/test/TaskHeritableStorage.jl
@@ -5,35 +5,33 @@ using Test
 using TaskHeritableStorage
 
 # Examples
-fetch(@async begin  # Put each test in its own Task so they don't share a task_heritable_storage
-    @task_heritable_storage()[:current_testset] = 5
-    fetch(@async begin
-        @test @task_heritable_storage()[:current_testset] == 5
-    end)
-end)
+struct ShallowCopyKey{sym} end
+TaskHeritableStorage.fork_task_local_storage(k::ShallowCopyKey, v) = (k,v)
 
-fetch(@async begin
-    @test TaskHeritableStorage._has_task_heritable_storage(@__MODULE__) == false
-    @task_heritable_storage()[:x] = 1
-    @test TaskHeritableStorage._has_task_heritable_storage(@__MODULE__) == true
-    @test fetch(@async TaskHeritableStorage._has_task_heritable_storage(@__MODULE__)) == true
+const key = ShallowCopyKey{:tls}()
+
+fetch(@async begin  # Put each test in its own Task so they don't share a task_heritable_storage
+    task_local_storage()[key] = 5
+    fetch(@async begin
+        @test task_local_storage()[key] == 5
+    end)
 end)
 
 @testset "assigning doesn't affect parent tasks" begin
     @sync @async begin
-        @task_heritable_storage()[:a] = 1
+        task_local_storage()[key] = 1
         @sync @async begin
-            @test @task_heritable_storage()[:a] == 1
+            @test task_local_storage()[key] == 1
 
             # Update it to 2 within this Task
-            @task_heritable_storage()[:a] = 2
-            @test @task_heritable_storage()[:a] == 2
+            task_local_storage()[key] = 2
+            @test task_local_storage()[key] == 2
         end
         # In the parent task, the value is still 1
-        @test @task_heritable_storage()[:a] == 1
+        @test task_local_storage()[key] == 1
     end
     # In the outermost task, the value was never set
-    @test !haskey(@task_heritable_storage(), :a)
+    @test !haskey(task_local_storage(), key)
 end
 
 @testset "callbacks" begin
@@ -42,7 +40,7 @@ end
         fetch(@async sort(args...; kwargs...))
     end
 
-    @testset "PROBLEM: task_local_storage isn't composable" begin
+    @testset "PROBLEM: normal task_local_storage isn't composable" begin
         task_local_storage()[:reverse] = false
         reversed() = task_local_storage()[:reverse]
 
@@ -61,9 +59,11 @@ end
         end  # VERSION
     end
 
-    @testset "SOLUTION: task_heritable_storage is composable" begin
-        @task_heritable_storage()[:reverse] = false
-        reversed() = @task_heritable_storage()[:reverse]
+    @testset "SOLUTION: Using a `fork_task_local_storage()` override _is_ composable" begin
+        reversekey = ShallowCopyKey{:reverse}()
+
+        task_local_storage()[reversekey] = false
+        reversed() = task_local_storage()[reversekey]
 
         less_than = (a,b) -> reversed() ? a>b : a<b
         @test sort(1:10, lt=less_than) == 1:10
@@ -74,15 +74,15 @@ end
 end
 
 @testset "functional interface" begin
-    @test haskey(@task_heritable_storage(), :x) == false
-    @task_heritable_storage(:x, 1) do
+    @test haskey(task_local_storage(), key) == false
+    task_local_storage(key, 1) do
         # Same Task
-        @test @task_heritable_storage()[:x] == 1
+        @test task_local_storage()[key] == 1
         # Nested Task
-        @test fetch(@async @task_heritable_storage()[:x]) == 1
+        @test fetch(@async task_local_storage()[key]) == 1
     end
     # Storage removed after the function returns
-    @test haskey(@task_heritable_storage(), :x) == false
+    @test haskey(task_local_storage(), key) == false
 end
 
 end

--- a/test/Tracing.jl
+++ b/test/Tracing.jl
@@ -9,29 +9,24 @@ else
     macro spawn(e) esc(:(@async(e))) end
 end
 
-begin
-    trace()
-    tasks, funcs = get_traces()
-    @info tasks
-    @info funcs
-end
+using Test
 
-begin
-    clear_traces()
-    trace()
-    @spawn begin
-        trace()
-        @spawn begin
-            trace()
-        end
-        @spawn begin
-            trace()
+@testset "Tracing example" begin
+
+    edges = tracetasks() do
+        @sync begin
+            @async begin
+                # Embedded trace within the parent trace
+                inneredges = @tracetasks 2+2
+                @assert length(inneredges) == 1
+            end
+            Threads.@spawn begin
+            end
         end
     end
 
-    tasks, funcs = get_traces()
-    @info tasks
-    @info funcs
-end
+    @test length(edges) == 3
 
 end
+
+end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,13 @@
 using TaskHeritableStorage  # Load the module (overrides Task() constructor)
 
-include("TaskHeritableStorage.jl")
+using Test
 
-# Examples
-include("ThreadSafeAccumulators.jl")
-include("Tracing.jl")
-# NOTE: MultiTest.jl currently modifies Test.@testset behavior, so keep it last:
-include("MultiTest.jl")
+@testset "TaskHeritableStorage" begin
+    include("TaskHeritableStorage.jl")
+
+    # Examples
+    include("ThreadSafeAccumulators.jl")
+    include("Tracing.jl")
+    # NOTE: MultiTest.jl currently modifies Test.@testset behavior, so keep it last:
+    include("MultiTest.jl")
+end


### PR DESCRIPTION
Switch to "Proposal 2": Have users override a `fork` function for their `(k,v)` pair types.

Advantages of this approach:
- Allows the user to customize the copying behavior for specific types (not just shallow copies, maybe _forking_ instead, or any other arbitrary behavior)
- Eliminates the need to have two separate storage locations within Tasks.
   - Simplifies logic for code to "know" when it's forking, rather than having to store extra metadata in the THS to find out if we're still in the same Task.

The  first commit actually makes the change:  b6af4a8
The second commit updates the examples and tests: 01628cd